### PR TITLE
Implement ROS teleop nodes and RL template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This repo hosts:
 - **unity/**: Unity 2021.3 LTS project scaffold (scene “TeleopDemo”)
 - **ros2_bridge/**: ROS 2 Humble packages to bridge teleop for Spot, Franka, UR, TurtleBot
-- **rl_envs/**: Templates for Isaac Sim & Gym environments
+- **rl_envs/**: Basic Python gym environments and training examples
 - **docs/**: Architecture & setup guides
 
 ## Getting Started
@@ -16,7 +16,12 @@ This repo hosts:
    - Open `Experiments/unity` with Unity 2021.3 LTS.
 3. ROS 2:
    ```bash
-   cd Experiments/ros2_bridge
-   colcon build
+ cd Experiments/ros2_bridge
+ colcon build
+ ```
+4. RL Environments:
+   ```bash
+   cd Experiments/rl_envs
+   python3 example_train.py
    ```
-4. See `/docs/architecture.md` for details.
+5. See `/docs/architecture.md` for details.

--- a/rl_envs/example_train.py
+++ b/rl_envs/example_train.py
@@ -1,0 +1,21 @@
+"""Example script that runs random policy on the SimpleEnv."""
+from simple_env import SimpleEnv
+import numpy as np
+
+
+def run_episode(env: SimpleEnv, steps: int = 20):
+    obs = env.reset()
+    total_reward = 0.0
+    for _ in range(steps):
+        action = env.action_space.sample()
+        obs, reward, done, _ = env.step(action)
+        total_reward += reward
+        if done:
+            break
+    return total_reward
+
+
+if __name__ == "__main__":
+    env = SimpleEnv()
+    reward = run_episode(env)
+    print(f"Episode reward: {reward}")

--- a/rl_envs/simple_env.py
+++ b/rl_envs/simple_env.py
@@ -1,0 +1,36 @@
+import gym
+import numpy as np
+
+class SimpleEnv(gym.Env):
+    """A minimal environment for demonstration purposes."""
+
+    metadata = {"render.modes": ["human"]}
+
+    def __init__(self):
+        super().__init__()
+        self.action_space = gym.spaces.Box(low=-1.0, high=1.0, shape=(1,), dtype=np.float32)
+        self.observation_space = gym.spaces.Box(low=-np.inf, high=np.inf, shape=(1,), dtype=np.float32)
+        self.state = np.zeros(1, dtype=np.float32)
+
+    def step(self, action):
+        self.state += action
+        reward = -np.linalg.norm(self.state)
+        done = bool(np.abs(self.state[0]) > 10.0)
+        return self.state.copy(), reward, done, {}
+
+    def reset(self):
+        self.state.fill(0.0)
+        return self.state.copy()
+
+    def render(self, mode="human"):
+        print(f"State: {self.state[0]:.2f}")
+
+if __name__ == "__main__":
+    env = SimpleEnv()
+    obs = env.reset()
+    for _ in range(5):
+        action = env.action_space.sample()
+        obs, reward, done, _ = env.step(action)
+        print("obs", obs, "reward", reward)
+        if done:
+            break

--- a/ros2_bridge/franka_teleop/CMakeLists.txt
+++ b/ros2_bridge/franka_teleop/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(franka_teleop_node src/franka_teleop_node.cpp)
 ament_target_dependencies(franka_teleop_node
   rclcpp sensor_msgs geometry_msgs std_msgs
 )
+target_compile_features(franka_teleop_node PUBLIC cxx_std_17)
 
 install(TARGETS franka_teleop_node
   DESTINATION lib/${PROJECT_NAME}

--- a/ros2_bridge/franka_teleop/src/franka_teleop_node.cpp
+++ b/ros2_bridge/franka_teleop/src/franka_teleop_node.cpp
@@ -1,0 +1,34 @@
+#include <memory>
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+
+class FrankaTeleopNode : public rclcpp::Node
+{
+public:
+  FrankaTeleopNode() : Node("franka_teleop_node")
+  {
+    using std::placeholders::_1;
+    sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+      "cmd_vel", 10, std::bind(&FrankaTeleopNode::twist_callback, this, _1));
+    pub_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel_out", 10);
+  }
+
+private:
+  void twist_callback(const geometry_msgs::msg::Twist::SharedPtr msg)
+  {
+    RCLCPP_INFO(this->get_logger(), "Received cmd_vel: linear=%.2f angular=%.2f",
+                msg->linear.x, msg->angular.z);
+    pub_->publish(*msg);
+  }
+
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pub_;
+};
+
+int main(int argc, char **argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<FrankaTeleopNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ros2_bridge/spot_teleop/CMakeLists.txt
+++ b/ros2_bridge/spot_teleop/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(spot_teleop_node src/spot_teleop_node.cpp)
 ament_target_dependencies(spot_teleop_node
   rclcpp sensor_msgs geometry_msgs std_msgs
 )
+target_compile_features(spot_teleop_node PUBLIC cxx_std_17)
 
 install(TARGETS spot_teleop_node
   DESTINATION lib/${PROJECT_NAME}

--- a/ros2_bridge/spot_teleop/src/spot_teleop_node.cpp
+++ b/ros2_bridge/spot_teleop/src/spot_teleop_node.cpp
@@ -1,0 +1,34 @@
+#include <memory>
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+
+class SpotTeleopNode : public rclcpp::Node
+{
+public:
+  SpotTeleopNode() : Node("spot_teleop_node")
+  {
+    using std::placeholders::_1;
+    sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+      "cmd_vel", 10, std::bind(&SpotTeleopNode::twist_callback, this, _1));
+    pub_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel_out", 10);
+  }
+
+private:
+  void twist_callback(const geometry_msgs::msg::Twist::SharedPtr msg)
+  {
+    RCLCPP_INFO(this->get_logger(), "Received cmd_vel: linear=%.2f angular=%.2f",
+                msg->linear.x, msg->angular.z);
+    pub_->publish(*msg);
+  }
+
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pub_;
+};
+
+int main(int argc, char **argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<SpotTeleopNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ros2_bridge/turtlebot_teleop/CMakeLists.txt
+++ b/ros2_bridge/turtlebot_teleop/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(turtlebot_teleop_node src/turtlebot_teleop_node.cpp)
 ament_target_dependencies(turtlebot_teleop_node
   rclcpp sensor_msgs geometry_msgs std_msgs
 )
+target_compile_features(turtlebot_teleop_node PUBLIC cxx_std_17)
 
 install(TARGETS turtlebot_teleop_node
   DESTINATION lib/${PROJECT_NAME}

--- a/ros2_bridge/turtlebot_teleop/src/turtlebot_teleop_node.cpp
+++ b/ros2_bridge/turtlebot_teleop/src/turtlebot_teleop_node.cpp
@@ -1,0 +1,34 @@
+#include <memory>
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+
+class TurtlebotTeleopNode : public rclcpp::Node
+{
+public:
+  TurtlebotTeleopNode() : Node("turtlebot_teleop_node")
+  {
+    using std::placeholders::_1;
+    sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+      "cmd_vel", 10, std::bind(&TurtlebotTeleopNode::twist_callback, this, _1));
+    pub_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel_out", 10);
+  }
+
+private:
+  void twist_callback(const geometry_msgs::msg::Twist::SharedPtr msg)
+  {
+    RCLCPP_INFO(this->get_logger(), "Received cmd_vel: linear=%.2f angular=%.2f",
+                msg->linear.x, msg->angular.z);
+    pub_->publish(*msg);
+  }
+
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pub_;
+};
+
+int main(int argc, char **argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<TurtlebotTeleopNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ros2_bridge/ur_teleop/CMakeLists.txt
+++ b/ros2_bridge/ur_teleop/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(ur_teleop_node src/ur_teleop_node.cpp)
 ament_target_dependencies(ur_teleop_node
   rclcpp sensor_msgs geometry_msgs std_msgs
 )
+target_compile_features(ur_teleop_node PUBLIC cxx_std_17)
 
 install(TARGETS ur_teleop_node
   DESTINATION lib/${PROJECT_NAME}

--- a/ros2_bridge/ur_teleop/src/ur_teleop_node.cpp
+++ b/ros2_bridge/ur_teleop/src/ur_teleop_node.cpp
@@ -1,0 +1,34 @@
+#include <memory>
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+
+class URTeleopNode : public rclcpp::Node
+{
+public:
+  URTeleopNode() : Node("ur_teleop_node")
+  {
+    using std::placeholders::_1;
+    sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+      "cmd_vel", 10, std::bind(&URTeleopNode::twist_callback, this, _1));
+    pub_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel_out", 10);
+  }
+
+private:
+  void twist_callback(const geometry_msgs::msg::Twist::SharedPtr msg)
+  {
+    RCLCPP_INFO(this->get_logger(), "Received cmd_vel: linear=%.2f angular=%.2f",
+                msg->linear.x, msg->angular.z);
+    pub_->publish(*msg);
+  }
+
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pub_;
+};
+
+int main(int argc, char **argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<URTeleopNode>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- flesh out teleop C++ nodes for Spot, Franka, Turtlebot and UR
- enable C++17 builds for all teleop packages
- add simple gym environment and training example
- update README with usage instructions

## Testing
- `colcon build --symlink-install` *(fails: command not found)*
- `python3 rl_envs/example_train.py` *(fails: ModuleNotFoundError: 'gym')*

------
https://chatgpt.com/codex/tasks/task_e_688406970d748329b70a3e9b3260e2e9